### PR TITLE
Use domain name from env in certbot command

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
+DOMAIN_NAME=broadband-188-255-24-92.ip.moscow.rt.ru
 
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,9 @@ services:
       - ./datawww/:/etc/nginx/html/
   certbot:
     image: certbot/certbot:latest
-    command: certonly --webroot --email yellow444@gmail.com --webroot-path /var/www/certbot/ --non-interactive --agree-tos -d broadband-188-255-24-92.ip.moscow.rt.ru
+    env_file:
+      - .env
+    command: certonly --webroot --email yellow444@gmail.com --webroot-path /var/www/certbot/ --non-interactive --agree-tos -d ${DOMAIN_NAME}
     # --dry-run
     volumes:
       - ./certbot/www/:/var/www/certbot/:rw


### PR DESCRIPTION
## Summary
- Define DOMAIN_NAME in .env
- Reference DOMAIN_NAME in certbot command
- Ensure certbot service loads environment variables from .env

## Testing
- `pytest -q`
- `docker compose config | sed -n '34,40p'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dd387474832da4003190f79155da